### PR TITLE
feat(cli): Add cli flag for (optionally) selecting the config file

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,11 +1,19 @@
 use clap::{Parser, ValueHint};
 use regex::Regex;
+use std::path::PathBuf;
 
 #[derive(Debug, Parser)]
 #[command(about, version)]
 pub struct Cli {
     #[clap(subcommand)]
     pub subcommand: SubCommand,
+    #[arg(
+        short,
+        long,
+        value_hint = ValueHint::FilePath,
+        default_value = "website-stalker.yaml",
+    )]
+    pub config: PathBuf,
 }
 
 #[derive(Debug, Parser)]
@@ -44,7 +52,7 @@ pub enum SubCommand {
             required_unless_present = "all",
         )]
         site_filter: Option<Regex>,
-    },
+    }
 }
 
 #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,5 +1,6 @@
 use anyhow::anyhow;
 use serde::{Deserialize, Serialize};
+use std::path::PathBuf;
 use url::Url;
 
 use crate::editor::regex_replacer::RegexReplacer;
@@ -87,8 +88,8 @@ impl Config {
         serde_yaml::to_string(&Self::example()).unwrap()
     }
 
-    pub fn load() -> anyhow::Result<Self> {
-        let filecontent = std::fs::read_to_string("website-stalker.yaml")?;
+    pub fn load(config: PathBuf) -> anyhow::Result<Self> {
+        let filecontent = std::fs::read_to_string(config)?;
         let mut config = serde_yaml::from_str::<Self>(&filecontent)?;
 
         if let Ok(from) = std::env::var("WEBSITE_STALKER_FROM") {


### PR DESCRIPTION
Hi! 👋 

This is an example on how one could add an optional configuration file flag to the cli.

I'm not sure if I nailed the usage of clap - specifying the flag twice (per `check` and `run`) feels odd.

This change should not break existing setups - since I do not have one, I could not test that claim.