### PR TITLE
feat(config): more descriptive example config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /target
+/sites

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /target
+
 /sites

--- a/src/config.rs
+++ b/src/config.rs
@@ -117,52 +117,8 @@ impl Config {
 }
 
 #[test]
-fn can_parse_example() {
-    use crate::editor::regex_replacer::RegexReplacer;
-    use crate::editor::Editor;
-
-    let string = EXAMPLE_CONF;
-    let parsed = serde_yaml::from_str::<Config>(&string).unwrap();
-
-    let example = Config {
-        from: "my-email-address".to_string(),
-        notification_template: None,
-        sites: vec![
-            SiteEntry {
-                url: Url::parse("https://edjopato.de/post/").unwrap().into(),
-                options: Options {
-                    accept_invalid_certs: false,
-                    ignore_error: false,
-                    headers: Vec::new(),
-                    editors: vec![
-                        Editor::CssSelect(".content".parse().unwrap()),
-                        Editor::CssRemove("a".parse().unwrap()),
-                        Editor::HtmlPrettify,
-                        Editor::RegexReplace(RegexReplacer {
-                            pattern: "\\d{4}-\\d{2}-\\d{2}".to_string(),
-                            replace: "ISO8601".to_string(),
-                        }),
-                    ],
-                },
-            },
-            SiteEntry {
-                url: Url::parse("https://edjopato.de/robots.txt").unwrap().into(),
-                options: Options {
-                    accept_invalid_certs: false,
-                    ignore_error: false,
-                    headers: Vec::new(),
-                    editors: vec![],
-                },
-            },
-        ],
-    };
-    assert_eq!(parsed, example);
-}
-
-#[test]
 fn example_sites_are_valid() {
-    let string = EXAMPLE_CONF;
-    let config = serde_yaml::from_str::<Config>(&string).unwrap();
+    let config = serde_yaml::from_str::<Config>(EXAMPLE_CONF).unwrap();
     config.validate_sites().unwrap();
 }
 
@@ -198,8 +154,7 @@ fn validate_fails_on_sites_list_with_empty_many() {
 
 #[test]
 fn validate_works_on_correct_mustache_template() {
-    let string = EXAMPLE_CONF;
-    let mut config = serde_yaml::from_str::<Config>(&string).unwrap();
+    let mut config = serde_yaml::from_str::<Config>(EXAMPLE_CONF).unwrap();
     config.notification_template = Some("Hello {{name}}".into());
     config.validate_notification_template().unwrap();
 }
@@ -207,8 +162,7 @@ fn validate_works_on_correct_mustache_template() {
 #[test]
 #[should_panic = "unclosed tag"]
 fn validate_fails_on_bad_mustache_template() {
-    let string = EXAMPLE_CONF;
-    let mut config = serde_yaml::from_str::<Config>(&string).unwrap();
+    let mut config = serde_yaml::from_str::<Config>(EXAMPLE_CONF).unwrap();
     config.notification_template = Some("Hello World {{".into());
     config.validate_notification_template().unwrap();
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -8,6 +8,26 @@ use crate::final_message::FinalMessage;
 use crate::http::validate_from;
 use crate::site::{Options, Site};
 
+pub const EXAMPLE_CONF: &str = "# This is an example config
+# The filename has to be `website-stalker.yaml`
+# and it has to be in the working directory where you run website-stalker.
+#
+# Adapt the config to your needs and set the FROM email address which is used as a request header:
+# https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/From
+#
+# Check if your config is valid via `website-stalker check`.
+# And then do a run via `website-stalker run --all`.
+#
+#
+# In this example, the website `edjopato.de` is tracked.
+# In particular, the `robots.txt`, as a minimal example of a `sites` target,
+# and the list of blogposts in `/post/`. Here, the use of `editors` is shown.
+# The `css_select` option specifies that all html tags within the `.content` class should be tracked.
+# Then all `a` tags (links) are removed.
+# Finally, `regex_replace` demonstrates how to replace the occurrence of time and date with the
+# name of their standard.
+";
+
 #[derive(Debug, Deserialize, Serialize, PartialEq, Eq)]
 pub struct Config {
     // Read as empty string when not defined as it could be overridden from the env
@@ -62,12 +82,12 @@ impl Config {
                         ignore_error: false,
                         headers: Vec::new(),
                         editors: vec![
-                            Editor::CssSelect("article".parse().unwrap()),
+                            Editor::CssSelect(".content".parse().unwrap()),
                             Editor::CssRemove("a".parse().unwrap()),
                             Editor::HtmlPrettify,
                             Editor::RegexReplace(RegexReplacer {
-                                pattern: "(Lesezeit): \\d+ \\w+".to_string(),
-                                replace: "$1".to_string(),
+                                pattern: "\\d{4}-\\d{2}-\\d{2}".to_string(),
+                                replace: "ISO8601".to_string(),
                             }),
                         ],
                     },

--- a/src/config.rs
+++ b/src/config.rs
@@ -125,7 +125,7 @@ fn can_parse_example() {
     let parsed = serde_yaml::from_str::<Config>(&string).unwrap();
 
     let example = Config {
-        from: "mail@example.org".to_string(),
+        from: "my-email-address".to_string(),
         notification_template: None,
         sites: vec![
             SiteEntry {

--- a/src/editor/regex_replacer.rs
+++ b/src/editor/regex_replacer.rs
@@ -53,3 +53,14 @@ fn replaces() -> anyhow::Result<()> {
     assert_eq!(result, "H w");
     Ok(())
 }
+
+#[test]
+fn replaces_iso() -> anyhow::Result<()> {
+    let example = RegexReplacer {
+        pattern: r#"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\+\d{2}:\d{2}"#.to_string(),
+        replace: "ISO8601".to_string(),
+    };
+    let result = example.replace_all("2022-02-14T22:31:00+01:00")?;
+    assert_eq!(result, "ISO8601");
+    Ok(())
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -51,8 +51,7 @@ async fn main() {
                 println!("Git repo initialized.");
             }
             if Config::load().is_err() {
-                let contents = config::EXAMPLE_CONF.to_string();
-                fs::write("website-stalker.yaml", contents)
+                fs::write("website-stalker.yaml", config::EXAMPLE_CONF)
                     .expect("failed to write example config file");
                 println!("Example config file generated.");
             }

--- a/src/main.rs
+++ b/src/main.rs
@@ -43,16 +43,8 @@ async fn main() {
     match cli::Cli::parse().subcommand {
         SubCommand::ExampleConfig => {
             println!(
-                "# This is an example config
-# The filename should be `website-stalker.yaml`
-# and it should be in the working directory where you run website-stalker.
-#
-# For example run `website-stalker example-config > website-stalker.yaml`.
-# Adapt the config to your needs and set the FROM email address which is used as a request header:
-# https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/From
-#
-# And then do a run via `website-stalker run --all`.
-{}",
+                "{}{}",
+                config::EXAMPLE_CONF,
                 Config::example_yaml_string()
             );
         }
@@ -64,10 +56,8 @@ async fn main() {
             }
             if Config::load().is_err() {
                 let contents = format!(
-                    "# This is an example config
-# Adapt it to your needs and check if its valid via `website-stalker check`.
-# In order to run use `website-stalker run --all`.
-{}",
+                    "{}{}",
+                    config::EXAMPLE_CONF,
                     Config::example_yaml_string()
                 );
                 fs::write("website-stalker.yaml", contents)

--- a/src/main.rs
+++ b/src/main.rs
@@ -51,7 +51,7 @@ async fn main() {
                 println!("Git repo initialized.");
             }
             if Config::load().is_err() {
-                let contents = format!("{}", config::EXAMPLE_CONF);
+                let contents = config::EXAMPLE_CONF.to_string();
                 fs::write("website-stalker.yaml", contents)
                     .expect("failed to write example config file");
                 println!("Example config file generated.");

--- a/src/main.rs
+++ b/src/main.rs
@@ -41,9 +41,7 @@ impl Display for ChangeKind {
 #[tokio::main]
 async fn main() {
     match cli::Cli::parse().subcommand {
-        SubCommand::ExampleConfig => {
-            println!("{}", config::EXAMPLE_CONF);
-        }
+        SubCommand::ExampleConfig => print!("{}", config::EXAMPLE_CONF),
         SubCommand::Init => {
             if git::Repo::new().is_err() {
                 git::Repo::init(std::env::current_dir().expect("failed to get working dir path"))

--- a/src/main.rs
+++ b/src/main.rs
@@ -42,11 +42,7 @@ impl Display for ChangeKind {
 async fn main() {
     match cli::Cli::parse().subcommand {
         SubCommand::ExampleConfig => {
-            println!(
-                "{}{}",
-                config::EXAMPLE_CONF,
-                Config::example_yaml_string()
-            );
+            println!("{}", config::EXAMPLE_CONF);
         }
         SubCommand::Init => {
             if git::Repo::new().is_err() {
@@ -55,11 +51,7 @@ async fn main() {
                 println!("Git repo initialized.");
             }
             if Config::load().is_err() {
-                let contents = format!(
-                    "{}{}",
-                    config::EXAMPLE_CONF,
-                    Config::example_yaml_string()
-                );
+                let contents = format!("{}", config::EXAMPLE_CONF);
                 fs::write("website-stalker.yaml", contents)
                     .expect("failed to write example config file");
                 println!("Example config file generated.");

--- a/website-stalker.yaml
+++ b/website-stalker.yaml
@@ -19,12 +19,12 @@
 ---
 from: my-email-address
 sites:
-  - url: "https://edjopato.de/post/"
+  - url: https://edjopato.de/post/
     editors:
-      - css_select: ".content"
+      - css_select: .content
       - css_remove: a
       - html_prettify
       - regex_replace:
-          pattern: "\\d{4}-\\d{2}-\\d{2}"
+          pattern: \d{4}-\d{2}-\d{2}
           replace: ISO8601
-  - url: "https://edjopato.de/robots.txt"
+  - url: https://edjopato.de/robots.txt

--- a/website-stalker.yaml
+++ b/website-stalker.yaml
@@ -17,7 +17,7 @@
 # Finally, `regex_replace` demonstrates how to replace the occurrence of time and date with the
 # name of their standard.
 ---
-from: mail@example.org
+from: my-email-address
 sites:
   - url: "https://edjopato.de/post/"
     editors:

--- a/website-stalker.yaml
+++ b/website-stalker.yaml
@@ -1,0 +1,30 @@
+# This is an example config
+# The filename has to be `website-stalker.yaml`
+# and it has to be in the working directory where you run website-stalker.
+#
+# Adapt the config to your needs and set the FROM email address which is used as a request header:
+# https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/From
+#
+# Check if your config is valid via `website-stalker check`.
+# And then do a run via `website-stalker run --all`.
+#
+#
+# In this example, the website `edjopato.de` is tracked.
+# In particular, the `robots.txt`, as a minimal example of a `sites` target,
+# and the list of blogposts in `/post/`. Here, the use of `editors` is shown.
+# The `css_select` option specifies that all html tags within the `.content` class should be tracked.
+# Then all `a` tags (links) are removed.
+# Finally, `regex_replace` demonstrates how to replace the occurrence of time and date with the
+# name of their standard.
+---
+from: mail@example.org
+sites:
+  - url: "https://edjopato.de/post/"
+    editors:
+      - css_select: ".content"
+      - css_remove: a
+      - html_prettify
+      - regex_replace:
+          pattern: "\\d{4}-\\d{2}-\\d{2}"
+          replace: ISO8601
+  - url: "https://edjopato.de/robots.txt"


### PR DESCRIPTION
Hi 👋 

While messing around, I noticed that the example config tries to `css_select` stuff that is not present on the example website. To be precise:
`https://edjopato.de/post/` no longer has an `article` class. 
This resulted in the following error:
`ERROR: https://edjopato.de/post/ css_selector (article) selected nothing`
Further, the regex example seemed also outdated.

This PR aims to fix both issues:
- `article` is replaced with `.content`
- The regex now replaces a date in iso format with the string `ISO8601`

 As well as adding the following feature:
- The example configuration now describes what the example does.

Additionally a refactoring of the code base was attempted:
- The two example-config header were merged into one. This makes the header a bit less fitting for each use case (init <-> print example) but the code base is simplified. I believe this to be a fair trade off, your opinion might differ - say so!
- The config header was moved to a `const` variable
- The config header location was changed from inline in `main.rs` to the top of `config.rs`

There is a test for the ISO8601 regex in this PR - I think it should be removed before merge as it does not test behaviour of the website-stalker. I left it in for this / the first review only. 