### PR TITLE
fix: clean error when no sites after site-filter

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -137,7 +137,12 @@ async fn run(do_commit: bool, site_filter: Option<&Regex>) -> anyhow::Result<()>
         .filter(|site| site_filter.map_or(true, |filter| filter.is_match(site.url.as_str())))
         .collect::<Vec<_>>();
     let sites_amount = sites.len();
-    assert!(!sites.is_empty(), "Site filter filtered everything out.");
+    if sites.is_empty() {
+        eprintln!("Error: The Site-filter filtered everything out.
+There are no sites tracked for your query.
+Tipp: Run 'website-stalker run --all' to stalk all tracked sites.");
+        process::exit(1);
+    }
 
     let distinct_domains = {
         let mut domains = sites

--- a/src/main.rs
+++ b/src/main.rs
@@ -138,9 +138,8 @@ async fn run(do_commit: bool, site_filter: Option<&Regex>) -> anyhow::Result<()>
         .collect::<Vec<_>>();
     let sites_amount = sites.len();
     if sites.is_empty() {
-        eprintln!("Error: The Site-filter filtered everything out.
-There are no sites tracked for your query.
-Tipp: Run 'website-stalker run --all' to stalk all tracked sites.");
+        eprintln!("Error: The site-filter filtered everything out.
+Hint: Change the filter or use all sites with 'run --all'.");
         process::exit(1);
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -138,8 +138,10 @@ async fn run(do_commit: bool, site_filter: Option<&Regex>) -> anyhow::Result<()>
         .collect::<Vec<_>>();
     let sites_amount = sites.len();
     if sites.is_empty() {
-        eprintln!("Error: The site-filter filtered everything out.
-Hint: Change the filter or use all sites with 'run --all'.");
+        eprintln!(
+            "Error: The site-filter filtered everything out.
+Hint: Change the filter or use all sites with 'run --all'."
+        );
         process::exit(1);
     }
 


### PR DESCRIPTION
Hi! 👋 

When accidentally running `website-stalker run all`, I got this error:
```
thread 'main' panicked at 'Site filter filtered everything out.', src/main.rs:130:5
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

which I disliked.

This PR changes that, the error now looks like this:
```
Error: The Site-filter filtered everything out.
There are no sites tracked for your query.
Tipp: Run 'website-stalker run --all' to stalk all tracked sites.
```

I believe this is better because:
- We can do a graceful exit here, no danger, no debugging needed, no panic
- Shows clearly this is an error - as opposed to failure/fault
- Shows what the user might did wrong
- Shows a possible solution for this error

Have a nice day!