### PR TITLE
chore(run): Print error without panic when config is invalid.

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -128,7 +128,13 @@ async fn main() {
 
 #[allow(clippy::too_many_lines)]
 async fn run(do_commit: bool, site_filter: Option<&Regex>) -> anyhow::Result<()> {
-    let config = Config::load().expect("failed to load config");
+    let config = match Config::load() {
+        Ok(config) => config,
+        Err(err) => {
+            eprintln!("Failed to load config.\n\n{err}\n\nCheck https://github.com/EdJoPaTo/website-stalker for configuration details.");
+            process::exit(1);
+        }
+    };
 
     let sites = config.get_sites();
     let sites_total = sites.len();


### PR DESCRIPTION
Hi! 🦓

The Rust docs say about `expect()`:  `Because this function may panic, its use is generally discouraged. Instead, prefer to use pattern matching and handle the [Err](https://doc.rust-lang.org/std/result/enum.Result.html#variant.Err) case explicitly[..]`

I tried to fix this accordingly.