### PR TITLE
feat: support URLs with IP addresses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - new editor: `html_sanitize`
 - `headers` site options to supply additional headers on requests
+- Support URLs with IP addresses
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -136,17 +136,17 @@ notification_template: |
   - {{.}}
   {{/sites}}
 
-  The following domains are involved:
-  {{#domains}}
+  The following hosts are involved:
+  {{#hosts}}
   - {{.}}
-  {{/domains}}
+  {{/hosts}}
 
-  {{#singledomain}}
-  All changes happened on only one domain: {{singledomain}}
-  {{/singledomain}}
-  {{^singledomain}}
-  The changes happened on various domains.
-  {{/singledomain}}
+  {{#singlehost}}
+  All changes happened on only one host: {{singlehost}}
+  {{/singlehost}}
+  {{^singlehost}}
+  The changes happened on various hosts.
+  {{/singlehost}}
 
   The {{commit}} contains all these changes.
 ```

--- a/src/main.rs
+++ b/src/main.rs
@@ -109,14 +109,14 @@ Hint: Change the filter or use all sites with 'run --all'."
         process::exit(1);
     }
 
-    let distinct_domains = {
-        let mut domains = sites
+    let distinct_hosts = {
+        let mut hosts = sites
             .iter()
-            .map(|o| o.url.domain().unwrap().to_string())
+            .map(|o| o.url.host_str().unwrap().to_string())
             .collect::<Vec<_>>();
-        domains.sort();
-        domains.dedup();
-        domains.len()
+        hosts.sort();
+        hosts.dedup();
+        hosts.len()
     };
 
     let repo = git::Repo::new();
@@ -153,16 +153,16 @@ Hint: Change the filter or use all sites with 'run --all'."
     if sites_amount < sites_total {
         logger::info(&format!("Your configuration file contains {sites_total} sites of which {sites_amount} are selected by your filter."));
     }
-    println!("Begin stalking of {sites_amount} sites on {distinct_domains} domains...");
-    if distinct_domains < sites_amount {
-        logger::info("Some sites are on the same domain. There is a wait time of 5 seconds between each request to the same domain in order to reduce load on the server.");
+    println!("Begin stalking of {sites_amount} sites on {distinct_hosts} hosts...");
+    if distinct_hosts < sites_amount {
+        logger::info("Some sites are on the same host. There is a wait time of 5 seconds between each request to the same host in order to reduce load on the server.");
     }
 
     let mut rx = {
         let (tx, rx) = channel(10);
         let groups = sites
             .into_iter()
-            .group_by(|a| a.url.domain().unwrap().to_string());
+            .group_by(|a| a.url.host_str().unwrap().to_string());
         for (_, group) in &groups {
             let from = config.from.clone();
             let site_store = site_store.clone();


### PR DESCRIPTION
Currently IP addresses are not supported as they don't have a domain. This PR changes that.

The filename is generated from the domain and then reversed (`edjopato.de` will have the filename `de-edjopato`) to sort by tld first. This is useless for IP addresses so the behaviour had to be different.

Also the notification template allows for `singledomain` and `domains` which is still supported but deprecated. Maybe #172 will drop notifications entirely and uses stdout so that change would be breaking too. Group them together and don't break it now.