### PR TITLE
fix(notifications): deprecate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - RSS: remove website-stalker version from the generator field
 - Instantly panic or print cleaner human error message
+- Deprecate notifications
 
 ## [0.22.0] - 2024-02-13
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ authors = ["EdJoPaTo <website-stalker-rust@edjopato.de>"]
 edition = "2021"
 
 [lints.rust]
+deprecated = "allow"
 unsafe_code = "forbid"
 [lints.clippy]
 pedantic = "warn"

--- a/README.md
+++ b/README.md
@@ -121,36 +121,6 @@ Alternatively you can specify FROM via environment variable
 export WEBSITE_STALKER_FROM=my-email-address
 ```
 
-#### `notification_template`
-
-When using the [notifications](#notifications) you might want to use your own style of notification instead of the default one.
-You can specify your own template which is handled via the [Mustache Syntax](https://mustache.github.io/mustache.5.html).
-The following example contains all currently available data points.
-
-When writing your own template use `website-stalker check` to ensure the template will work.
-
-```yaml
-notification_template: |
-  These {{siteamount}} sites changed:
-  {{#sites}}
-  - {{.}}
-  {{/sites}}
-
-  The following hosts are involved:
-  {{#hosts}}
-  - {{.}}
-  {{/hosts}}
-
-  {{#singlehost}}
-  All changes happened on only one host: {{singlehost}}
-  {{/singlehost}}
-  {{^singlehost}}
-  The changes happened on various hosts.
-  {{/singlehost}}
-
-  The {{commit}} contains all these changes.
-```
-
 ### Per Site Config Options
 
 Options available per site besides the [editors](#editors) which are explained below.
@@ -417,23 +387,6 @@ Examples:
   - url: "https://edjopato.de/post/"
     editors:
       - rss: {}
-```
-
-### Notifications
-
-When changes on websites are detected they get saved to the file system.
-When `--commit` is given a git commit is created.
-
-Additionally, you can get notified via Telegram, Slack, E-Mail, ...
-[`pling`](https://github.com/EdJoPaTo/pling) is used to send these notifications.
-Check its documentation about which environment variables to specify in order to get notifications.
-
-Example with Telegram:
-
-```bash
-export TELEGRAM_BOT_TOKEN='123:ABC'
-export TELEGRAM_TARGET_CHAT='1234'
-website-stalker run --all
 ```
 
 ## Alternatives

--- a/src/config.rs
+++ b/src/config.rs
@@ -3,6 +3,7 @@ use serde::Deserialize;
 use url::Url;
 
 use crate::http::validate_from;
+use crate::logger;
 use crate::notification::validate_template;
 use crate::site::{Options, Site};
 
@@ -14,6 +15,7 @@ pub struct Config {
     #[serde(default)]
     pub from: String,
 
+    #[deprecated = "The notification feature will be removed"]
     #[serde(
         default,
         deserialize_with = "deserialize_mustache_template",
@@ -106,6 +108,7 @@ fn deserialize_mustache_template<'de, D>(
 where
     D: serde::Deserializer<'de>,
 {
+    logger::warn_deprecated_notifications();
     let str = String::deserialize(deserializer)?;
     let template = mustache::compile_str(&str).map_err(serde::de::Error::custom)?;
     validate_template(&template).map_err(serde::de::Error::custom)?;

--- a/src/logger.rs
+++ b/src/logger.rs
@@ -1,4 +1,5 @@
 use std::env;
+use std::sync::atomic::{AtomicBool, Ordering};
 
 use once_cell::sync::Lazy;
 
@@ -27,4 +28,12 @@ pub fn warn(message: &str) {
 
 pub fn info(message: &str) {
     eprintln!("INFO: {message}");
+}
+
+pub fn warn_deprecated_notifications() {
+    static HAS_WARNED: AtomicBool = AtomicBool::new(false);
+    let before = HAS_WARNED.swap(true, Ordering::Relaxed);
+    if !before {
+        warn("Notifications are deprecated and will be replaced by a simpler machine-readable output. This way you will be able to control the exact notifications even better yourself. The details on this are not yet finalized. Please join the discussion on https://github.com/EdJoPaTo/website-stalker/discussions/172");
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -60,7 +60,10 @@ async fn main() {
         }
         Cli::Check => {
             let notifiers = pling::Notifier::from_env().len();
-            eprintln!("Notifiers: {notifiers}. Check https://github.com/EdJoPaTo/pling/ for configuration details.");
+            if notifiers > 0 {
+                logger::warn_deprecated_notifications();
+                eprintln!("Notifiers: {notifiers}. Check https://github.com/EdJoPaTo/pling/ for configuration details.");
+            }
 
             eprintln!("\nConfiguration...");
             match Config::load() {
@@ -218,6 +221,7 @@ async fn run(do_commit: bool, site_filter: Option<&Regex>) {
     if !urls_of_interest.is_empty() {
         let notifiers = pling::Notifier::from_env();
         if !notifiers.is_empty() {
+            logger::warn_deprecated_notifications();
             let message = notification::MustacheData::new(commit, urls_of_interest)
                 .apply_to_template(config.notification_template.as_ref())
                 .expect("Should be able to create notification message from template");

--- a/src/notification.rs
+++ b/src/notification.rs
@@ -1,5 +1,3 @@
-#![allow(deprecated)] // TODO: remove on breaking release
-
 use once_cell::sync::Lazy;
 use url::Url;
 
@@ -25,6 +23,7 @@ See {{.}}
     .unwrap()
 });
 
+#[deprecated = "The notification feature will be removed"]
 #[derive(serde::Serialize)]
 pub struct MustacheData {
     commit: Option<String>,


### PR DESCRIPTION
I want to create some churn. The discussion on #172 is pretty much dead for way too long, and I want the notifications to be gone. Release the next version which will be annoying for people using notifications. ([There aren't that many](https://github.com/search?q=notification_template+path%3Awebsite-stalker.yaml&type=code))

Maybe people join in, or it does not seem that important of a feature anyway.

@Teufelchen1 would you like to do a sanity check before I merge this?