### PR TITLE
feat(notification): default commit template on GitHub Actions

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -34,7 +34,8 @@ pub enum Cli {
         /// When it's not in the template the commit hash is concatinated to the template: `{template}{commit}`.
         ///
         /// For example with GitHub this would be:
-        /// <https://github.com/EdJoPaTo/website-stalker-example/commit/{commit}>
+        /// <https://github.com/EdJoPaTo/website-stalker-example/commit/{commit}>.
+        /// When run via GitHub Actions this is the default.
         #[arg(
             long,
             env,

--- a/src/github.rs
+++ b/src/github.rs
@@ -1,0 +1,29 @@
+/*!
+GitHub related logic
+
+# Documentation
+- <https://docs.github.com/en/actions/learn-github-actions/variables#default-environment-variables>
+- <https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions>
+*/
+
+use std::env;
+
+use once_cell::sync::Lazy;
+
+pub static IS_RUN_AS_GITHUB_ACTION: Lazy<bool> =
+    Lazy::new(|| env::var_os("GITHUB_ACTIONS").is_some());
+
+pub fn error(message: &str) {
+    println!("::error file=website-stalker.yaml::{message}");
+}
+
+pub fn warning(message: &str) {
+    println!("::warning file=website-stalker.yaml::{message}");
+}
+
+/// See [`crate::notification`]
+pub fn commit_prefix() -> Option<String> {
+    let server = env::var("GITHUB_SERVER_URL").ok()?;
+    let repo = env::var("GITHUB_REPOSITORY").ok()?;
+    Some(format!("{server}/{repo}/commit/"))
+}

--- a/src/logger.rs
+++ b/src/logger.rs
@@ -1,8 +1,4 @@
-use std::env;
-
-use once_cell::sync::Lazy;
-
-static GHA: Lazy<bool> = Lazy::new(|| env::var_os("GITHUB_ACTIONS").is_some());
+use crate::github;
 
 pub fn error_exit(message: &str) -> ! {
     error(message);
@@ -10,16 +6,16 @@ pub fn error_exit(message: &str) -> ! {
 }
 
 pub fn error(message: &str) {
-    if *GHA {
-        println!("::error file=website-stalker.yaml::{message}");
+    if *github::IS_RUN_AS_GITHUB_ACTION {
+        github::error(message);
     } else {
         eprintln!("ERROR: {message}");
     }
 }
 
 pub fn warn(message: &str) {
-    if *GHA {
-        println!("::warning file=website-stalker.yaml::{message}");
+    if *github::IS_RUN_AS_GITHUB_ACTION {
+        github::warning(message);
     } else {
         eprintln!("WARN: {message}");
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -18,6 +18,7 @@ mod config;
 mod editor;
 mod filename;
 mod git;
+mod github;
 mod http;
 mod logger;
 mod notification;
@@ -241,8 +242,11 @@ async fn run(
         });
 
     if !urls_of_interest.is_empty() {
-        let message =
-            notification::generate_text(commit, notification_commit_template, urls_of_interest);
+        let message = notification::generate_text(
+            commit,
+            notification_commit_template.or_else(github::commit_prefix),
+            urls_of_interest,
+        );
         if let Err(err) = notifications.send_reqwest(&message).await {
             logger::error(&format!("notifier failed to send with Err: {err}"));
         }


### PR DESCRIPTION
Other things in this tool also work well with GitHub Actions.

The user could specify the following in their workflow, but this could also be integrated into this tool. It basically reduces mistakes on configuration and assumes good defaults when running on GitHub Actions.

```yaml
env:
  NOTIFICATION_COMMIT_TEMPLATE: ${{ github.server_url }}/${{ github.repository }}/commit/
```