### PR TITLE
fix(notification): dont group single host

### DIFF
--- a/src/notification.rs
+++ b/src/notification.rs
@@ -25,14 +25,15 @@ fn generate_change_lines(mut changed: Vec<Url>) -> String {
         }
     }
 
-    for (host, urls) in changed_hosts {
+    for urls in changed_hosts.values() {
         if urls.len() > 1 {
-            _ = writeln!(text, "\n{host}");
+            _ = writeln!(text);
             for url in urls {
                 _ = writeln!(text, "- {url}");
             }
         }
     }
+
     text.trim().to_owned()
 }
 
@@ -106,21 +107,37 @@ mod change_lines_tests {
     }
 
     #[test]
-    fn same_host() {
+    fn multiple_on_single_host() {
         test(
             &["https://edjopato.de/", "https://edjopato.de/post/"],
-            "edjopato.de
-- https://edjopato.de/
+            "- https://edjopato.de/
 - https://edjopato.de/post/",
+        );
+    }
+
+    #[test]
+    fn multiple_per_host() {
+        test(
+            &[
+                "https://edjopato.de/",
+                "https://edjopato.de/post/",
+                "https://example.com/",
+                "https://example.com/path",
+            ],
+            "- https://edjopato.de/
+- https://edjopato.de/post/
+
+- https://example.com/
+- https://example.com/path",
         );
     }
 
     #[test]
     fn different_hosts() {
         test(
-            &["https://edjopato.de/post/", "https://foo.bar/"],
+            &["https://edjopato.de/post/", "https://example.com/"],
             "- https://edjopato.de/post/
-- https://foo.bar/",
+- https://example.com/",
         );
     }
 
@@ -130,11 +147,10 @@ mod change_lines_tests {
             &[
                 "https://edjopato.de/",
                 "https://edjopato.de/post/",
-                "https://foo.bar/",
+                "https://example.com/",
             ],
-            "- https://foo.bar/
+            "- https://example.com/
 
-edjopato.de
 - https://edjopato.de/
 - https://edjopato.de/post/",
         );


### PR DESCRIPTION
The front of all the URLs has the host anyway, and it's cleaner to read when multiple on a single host change.
Especially when some repos only check a single host.

To simplify the code we could just always create an empty line between different hosts, but that would end up long for many changes on different hosts.

@Teufelchen1 interested in a review?