### PR TITLE
fix(clippy): Make clippy happy

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -28,7 +28,7 @@ pub enum UrlVariants {
 }
 
 impl UrlVariants {
-    pub fn is_empty(&self) -> bool {
+    pub const fn is_empty(&self) -> bool {
         match self {
             Self::Single(_) => false,
             Self::Many(many) => many.is_empty(),
@@ -112,8 +112,9 @@ impl Config {
                 .is_some_and(|key| OLD_PLING_ENV_VARS.contains(&key))
         }) {
             logger::warn(&format!(
-                "Environment variable {key:?} was part of the old notification setup. Check website-stalker run --help for the new notification settings."
-            ));
+                "Environment variable {} was part of the old notification setup. Check website-stalker run --help for the new notification settings.",
+                key.display())
+            );
         }
 
         Ok(())


### PR DESCRIPTION
Hello :giraffe: 

I noticed that the last commit failed the CI. Turns out, clippy was unhappy.
This PR makes clippy happy once more.

A. I found the change to `key.display()` ugly
B. Not sure why but cargo fmt refused to format my lines 115-117 for me. So I had to guess. It even refused to fix out right stupid formatting. Did you over do it with the fmt.toml? Maybe something broke.